### PR TITLE
Loadable auto guide for DPVI

### DIFF
--- a/tests/dpvi/dpvi_test.py
+++ b/tests/dpvi/dpvi_test.py
@@ -20,6 +20,7 @@ import jax.numpy as jnp
 import numpy as np
 from numpyro.primitives import sample, plate, param
 from numpyro import distributions as dists
+from numpyro.infer.autoguide import AutoDiagonalNormal
 import pandas as pd
 import tempfile
 import pytest
@@ -306,6 +307,37 @@ class DPVIResultTests(unittest.TestCase):
             self.assertTrue(
                 (result_samples.values == loaded_result_samples.values).all().all()
             )
+
+    def test_store_and_load_without_guide(self) -> None:
+        """ Test to reproduce #48. """
+        from twinify.dpvi.loadable_auto_guide import LoadableAutoGuide
+        guide = LoadableAutoGuide(model, ["first", "another"], AutoDiagonalNormal)
+
+        result = DPVIResult(
+            self.model, guide, self.params, self.privacy_params, self.final_elbo, self.data_description
+        )
+
+        with tempfile.TemporaryFile("w+b") as f:
+            result.store(f)
+
+            f.seek(0)
+            loaded_result = DPVIResult.load(f, model=self.model)
+
+            self.assertTrue(
+                jax.tree_util.tree_all(
+                    jax.tree_util.tree_map(jnp.allclose, self.params, loaded_result.parameters)
+                )
+            )
+            self.assertEqual(self.privacy_params, loaded_result.privacy_level)
+            self.assertEqual(self.final_elbo, loaded_result.final_elbo)
+            self.assertEqual(self.data_description, loaded_result.data_description)
+
+            result_samples = result.generate(d3p.random.PRNGKey(567), 10, 1)
+            loaded_result_samples = loaded_result.generate(d3p.random.PRNGKey(567), 10, 1)
+            self.assertTrue(
+                (result_samples.values == loaded_result_samples.values).all().all()
+            )
+
 
 
 if __name__ == '__main__':

--- a/tests/dpvi/dpvi_test.py
+++ b/tests/dpvi/dpvi_test.py
@@ -308,10 +308,10 @@ class DPVIResultTests(unittest.TestCase):
                 (result_samples.values == loaded_result_samples.values).all().all()
             )
 
-    def test_store_and_load_without_guide(self) -> None:
+    def test_store_and_load_with_loadable_autoguide(self) -> None:
         """ Test to reproduce #48. """
         from twinify.dpvi.loadable_auto_guide import LoadableAutoGuide
-        guide = LoadableAutoGuide(model, ["first", "another"], AutoDiagonalNormal)
+        guide = LoadableAutoGuide(model, ["ys", "xs", "cats"], AutoDiagonalNormal)
 
         result = DPVIResult(
             self.model, guide, self.params, self.privacy_params, self.final_elbo, self.data_description

--- a/twinify/dpvi/dpvi_model.py
+++ b/twinify/dpvi/dpvi_model.py
@@ -31,9 +31,9 @@ from twinify.base import InferenceModel
 from tqdm import tqdm
 
 from twinify.dpvi import PrivacyLevel, ModelFunction, GuideFunction
+from twinify.dpvi.loadable_auto_guide import LoadableAutoGuide
 from twinify.dpvi.dpvi_result import DPVIResult
 from twinify.dataframe_data import DataDescription
-
 
 class InferenceException(Exception):
 
@@ -112,7 +112,7 @@ class DPVIModel(InferenceModel):
         self._model = model
 
         if guide is None:
-            guide = self.create_default_guide(model)
+            guide = LoadableAutoGuide.wrap_for_inference(self.create_default_guide(model))
 
         self._guide = guide
         self._clipping_threshold = clipping_threshold

--- a/twinify/dpvi/dpvi_model.py
+++ b/twinify/dpvi/dpvi_model.py
@@ -15,7 +15,8 @@
 
 import pandas as pd
 
-from typing import Optional, Any, Tuple
+from typing import Optional
+import warnings
 
 import numpy as np
 import jax
@@ -87,6 +88,12 @@ class SilenceableProgressBar:
 
 class DPVIModel(InferenceModel):
 
+    DefaultAutoGuideType = numpyro.infer.autoguide.AutoDiagonalNormal
+
+    @staticmethod
+    def create_default_guide(model: ModelFunction) -> GuideFunction:
+        return DPVIModel.DefaultAutoGuideType(model)
+
     def __init__(
             self,
             model: ModelFunction,
@@ -112,16 +119,18 @@ class DPVIModel(InferenceModel):
         self._model = model
 
         if guide is None:
-            guide = LoadableAutoGuide.wrap_for_inference(self.create_default_guide(model))
+            guide = LoadableAutoGuide.wrap_for_inference(self.DefaultAutoGuideType)(model)
+        else:
+            if isinstance(guide, numpyro.infer.autoguide.AutoGuide):
+                warnings.warn(
+                    "It seems that you are using an AutoGuide instance, which may result in problems after loading a stored inference model."
+                    "Consider wrapping it with twinify.dpvi.LoadableAutoGuide."
+                )
 
         self._guide = guide
         self._clipping_threshold = clipping_threshold
         self._num_epochs = num_epochs
         self._subsample_ratio = subsample_ratio
-
-    @staticmethod
-    def create_default_guide(model: ModelFunction) -> GuideFunction:
-        return numpyro.infer.autoguide.AutoDiagonalNormal(model)
 
     def fit(self,
             data: pd.DataFrame,

--- a/twinify/dpvi/dpvi_result.py
+++ b/twinify/dpvi/dpvi_result.py
@@ -120,7 +120,7 @@ class DPVIResult(InferenceResult):
         if guide is None:
             from twinify.dpvi.dpvi_model import DPVIModel
             guide = LoadableAutoGuide.wrap_for_sampling_and_initialize(
-                DPVIModel.create_default_guide(model), observation_sites
+                DPVIModel.DefaultAutoGuideType, observation_sites
             )(model)
 
         return DPVIResult(model, guide, parameters, privacy_parameters, final_elbo, data_description)

--- a/twinify/dpvi/loadable_auto_guide.py
+++ b/twinify/dpvi/loadable_auto_guide.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2023- twinify Developers and their Assignees
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Callable, Dict, Iterable, Optional, Type
+from numpyro.infer.autoguide import AutoGuide
+from numpyro.handlers import condition, trace, seed, block
+import jax.random
+
+from twinify.dpvi import ModelFunction
+
+__all__ = ['LoadableAutoGuide']
+
+class LoadableAutoGuide(AutoGuide):
+    """
+    Wraps any given AutoGuide class and allows it to be used in sampling without
+    first running inference, given only a list of known observation sites in the model
+    and previously learned parameters.
+
+    The main intent is to facilitate sampling from the guide in a separate
+    script than the inference took place, i.e., when the particular guide instance
+    was never used for inference, which is not possible with regular AutoGuide instances.
+    """
+    # TODO: consider moving initialization into construction, in a RAII manner.
+    #   Currently construction results in a half-initialized object, which invites highly error prone user code.
+
+    def __init__(self,
+            model: ModelFunction,
+            observation_sites: Optional[Iterable[str]],
+            base_guide_class: Type[AutoGuide],
+            *base_guide_args: Any,
+            **base_guide_kwargs: Any) -> None:
+        """
+        Creates a LoadableAutoGuide for the given `base_guide_class`. If `observation_sites`
+        are not `None` and cover all sampling sites which `model` is conditioned on - i.e., those
+        which should not be affected by `base_guide_class` - the created LoadableAutoGuide can be used
+        for sampling without being used in inference first.
+
+        If `observation_sites` are `None`, using the created LoadableAutoGuide in inference
+        will behave exactly as using an instance of `base_guide_class` but will additionally
+        extract the the sampling sites which `model` is conditioned on during inference and
+        make them avaiable via the `observation_sites` property. These can then be used
+        to initialise LoadableAutoGuide instances for sampling without inference later on.
+
+        Args:
+            model (ModelFunction): The model function.
+            observation_sites (Iterable[str]): Optional collection of parameter site names that are observations in the model
+                and should not be sampled from the guide.
+            base_guide_class (Type[AutoGuide]): The AutoGuide subclass to wrap around (NOT a class instance!).
+            base_guide_args: Positional arguments to pass into `base_guide_class`'s initializer.
+            base_guide_kwargs: Keyword arguments to pass into `base_guide_class`'s initializer.
+        """
+        if base_guide_class == LoadableAutoGuide:
+            raise ValueError("LoadableAutoGuide cannot wrap itself.")
+
+        self._model = model
+        self._base_guide_factory = lambda model: base_guide_class(model, *base_guide_args, **base_guide_kwargs) # TODO: there is a bug that occurs in AutoDiagonalGuide.initialize_model due to a None rng_key that seems to originate from here when used in wrap_for_sampling_and_initalize; investigate and fix
+        self._obs = frozenset(observation_sites) if observation_sites is not None else None
+        self._guide = None
+
+    @staticmethod
+    def wrap_for_inference(base_guide_class: Type[AutoGuide]) -> Callable[[Any], "LoadableAutoGuide"]:
+        """
+        Returns a callable accepting a model and model arguments and returns a LoadableAutoGuide
+        instance for `base_guide_class` (an AutoGuide subtype) set up for inference (but not yet initialized).
+
+        Args:
+            base_guide_class (Type[AutoGuide]): The AutoGuide subclass to wrap around (NOT a class instance!).
+
+        Returns:
+            Callable[[ModelFunction, Any...], LoadableAutoGuide]
+        """
+        def wrapped_for_inference(model: ModelFunction, *args, **kwargs):
+            return LoadableAutoGuide(model, None, base_guide_class, *args, **kwargs)
+        return wrapped_for_inference
+
+    @staticmethod
+    def wrap_for_sampling(base_guide_class: Type[AutoGuide], observation_sites: Iterable[str]) -> Callable[[Any], "LoadableAutoGuide"]:
+        """
+        Returns a callable accepting a model and model arguments and returns a LoadableAutoGuide
+        instance for `base_guide_class` (an AutoGuide subtype) set up for sampling (but not yet initialized).
+
+        Args:
+            base_guide_class (Type[AutoGuide]): The AutoGuide subclass to wrap around (NOT a class instance!).
+            observation_sites (Iterable[str]): Collection of parameter site names that are observations in the model
+                and should not be sampled from the guide.
+
+        Returns:
+            Callable[[ModelFunction, Any...], LoadableAutoGuide]
+        """
+        def wrapped_for_sampling(model: Callable, *args, **kwargs):
+            return LoadableAutoGuide(model, observation_sites, base_guide_class, *args, **kwargs)
+        return wrapped_for_sampling
+
+    @staticmethod
+    def wrap_for_sampling_and_initialize(
+            base_guide_class: Type[AutoGuide],
+            observation_sites: Iterable[str],
+            *model_args: Any, **model_kwargs) -> Callable[[Any], "LoadableAutoGuide"]:
+        """
+        Returns a callable accepting a model and base guide arguments and returns a LoadableAutoGuide
+        instance for `base_guide_class` (an AutoGuide subtype) ready for use for sampling without running inference.
+
+        Equivalent to running:
+        LoadableAutoGuide.wrap_for_sampling(base_guide_class, observation_sites)(model).initialize(*model_args, **model_kwargs).
+
+        Args:
+            base_guide_class (Type[AutoGuide]): The AutoGuide subclass to wrap around (NOT a class instance!).
+            observation_sites (Iterable[str]): Collection of parameter site names that are observations in the model
+                and should not be sampled from the guide.
+            model_args (Any): Optional positional arguments to be passed through to the model.
+            model_kwargs (Any): Optional keyword arguments to be passed through to the model.
+
+        Returns:
+            Callable[[ModelFunction, Any...], LoadableAutoGuide]
+        """
+        def wrapped_for_sampling_with_init(model: Callable, *base_guide_args, **base_guide_kwargs):
+            guide = LoadableAutoGuide(
+                model, observation_sites, base_guide_class, *base_guide_args, **base_guide_kwargs
+            )
+            guide.initialize(*model_args, **model_kwargs)
+            return guide
+        return wrapped_for_sampling_with_init
+
+    def initialize(self, *args: Any, **kwargs: Any) -> Any:
+        """
+        Traces through the model function provided to this LoadableAutoGuide instance during construction
+        and prepares this instance for usage.
+
+        If observation sites were provided, traces through the model to determine the parameter space
+        of the guide, resulting in an instance that can be used for sampling without being used in inference first.
+        """
+        if self._guide is not None: return
+
+        if self._obs is not None:
+            # We are given a set of observation sites that should be ignored by the guide
+            # Here's the general strategy: NumPyro AutoGuide requires that all
+            # parameters sites corresponding to observations need to be conditioned
+            # on, but this is not case yet. To do so, we sample some data from the
+            # prior predictive distribution (using the model function) and condition
+            # the model on those for the guide initialisation.
+
+            # We will probably be in the middle of a sampling stack so we block
+            # all handlers sitting above the guide while we initialize it
+            with block():
+
+                # get plausible fake values for observed sites from prior
+                with trace() as tr:
+                    seed(self._model, jax.random.PRNGKey(0))(*args, **kwargs)
+                    fake_obs = {site: val['value'] for site, val in tr.items() if site in self._obs}
+
+                # feed model conditioned on fake observations to guide
+                guide = self._base_guide_factory(condition(self._model, fake_obs))
+                # trigger guide initialisation with fake observatons
+                seed(guide, jax.random.PRNGKey(0))(*args, **kwargs)
+
+            self._guide = guide
+        else:
+            # We are not given a set of observation sites, so we assume this call is
+            # part of inference. We don't need to do anything to the guide.
+            # However, we trace through the model to collect all observation sites
+            # that it is conditioned on.
+
+            with block():
+                with trace() as tr:
+                    seed(self._model, jax.random.PRNGKey(0))(*args, **kwargs)
+                self._obs = [name for name, site in tr.items() if site.get('is_observed', False)]
+
+            guide = self._base_guide_factory(self._model) # initialise guide with model as normal
+            self._guide = guide
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        if self._guide is None:
+            self.initialize(*args, **kwargs)
+
+        return self._guide.__call__(*args, **kwargs)
+
+    @property
+    def base_guide(self) -> AutoGuide:
+        """
+        The instance of type base_guide_class this LoadableAutoGuide instance wraps around.
+
+        Note: Requires initialization.
+        """
+        if not self.is_initialized:
+            raise RuntimeError("The guide must be initialized from the model first! "\
+                "You can call initialize(*model_args, **model_kwargs) to do so.")
+        return self._guide
+
+    def sample_posterior(self, rng_key, params, *args, **kwargs):
+        return self.base_guide.sample_posterior(rng_key, params, *args, **kwargs)
+
+    @property
+    def observation_sites(self) -> Iterable[str]:
+        """
+        The observation sites in the model, i.e., sample sites that are not
+        sampled from the guide.
+
+        If observation sites were provided during construction, the collection returned by this
+        function will be identical. If not, this function returns the observation sites
+        identified from the model during initialization of the guide.
+        """
+        return self._obs
+
+    def median(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Returns the posterior median value of each latent variable.
+
+        Note: Requires initialization.
+
+        Args:
+            params (Dict[str, Any]): A dict containing parameter values.
+                The parameters can be obtained using :meth:`~numpyro.infer.svi.SVI.get_params`
+                method from :class:`~numpyro.infer.svi.SVI`.
+        Returns: A dict mapping sample site name to median value.
+        """
+
+        return self.base_guide.median(params)
+
+    def quantiles(self, params: Dict[str, Any], quantiles: Iterable[float]) -> Dict[str, Any]:
+        """
+        Returns posterior quantiles each latent variable. Example::
+
+            print(guide.quantiles(params, [0.05, 0.5, 0.95]))
+
+        Note: Requires initialization.
+
+        Args:
+            params (Dict[str, Any]): A dict containing parameter values.
+                The parameters can be obtained using :meth:`~numpyro.infer.svi.SVI.get_params`
+                method from :class:`~numpyro.infer.svi.SVI`.
+            quantiles (Iterable[float]): A list of requested quantiles between 0 and 1.
+
+        Returns:A dict mapping sample site name to an array of quantile values.
+        """
+        return self.base_guide.quantiles(params, quantiles)
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._guide is not None


### PR DESCRIPTION
This is a (partial) fix for #48 .

That issue affects use of numpyro's AutoGuide derivates in sampling after loading a stored parameters. These classes typically must be used in inference before they can be used for making predictions (due to the way they internally trace through the model to determine the relevant parameter sites that must be covered by the variational distribution / model prior). Note that this is only relevant to determine the structure of the variational distribution and the actual data used during inference is of no relevance to this process.

This fix solves this problem by introducing a wrapper around `AutoGuide` classes, `twinify.dpvi.LoadableAutoGuide`, which:
- when used during inference, stores the model sampling sites corresponding to data/observations (i.e., those not corresponding to model parameters covered by the variational distribution)
- when used during sampling and given a set of observation sites, initialises the `AutoGuide` class by simulating an inference run with data sampled from the prior predictive distribution.

This is a quick fix and will require further documentation to ensure users use `LoadableAutoGuide` instead of `AutoGuide`, when requires. Currently the system only issues a warning if a plain `AutoGuide` instance is used. Automatic wrapping of provided `AutoGuide` instance would be preferred and is something we could look into for the future. Solving the more fundamental issue of somehow storing model and guide directly would also help.