### PR TITLE
NapsuMQModel: renamed arg column_feature_set to required_marignals

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ a representation of the model fitted to the data in the form of a `InferenceResu
 
 Currently twinify provides `twinify.dpvi.DPVIModel` and `twinify.napsu_mq.NapsuMQModel` as concrete implementations, with the following initializers:
 - `DPVIModel(model: NumPyroModelFunction, guide: Optional[NumPyroGuideFunction] = None, clipping_threshold: float = 1., num_epochs: int = 1000, subsample_ratio: float = 0.01)`
-- `NapsuMQModel(column_feature_set: Iterable[FrozenSet[str]], use_laplace_approximation: bool = True)`
+- `NapsuMQModel(required_marginals: Iterable[FrozenSet[str]] = tuple(), use_laplace_approximation: bool = True)`
 
 #### `InferenceResult`
 `InferenceResult` represents a learned model from which synthetic data can be generated. To that end it defines the method

--- a/examples/NapsuMQ example.ipynb
+++ b/examples/NapsuMQ example.ipynb
@@ -2,15 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "source": [
-    "# Twinify example: NapsuMQ usage"
-   ],
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "# Twinify example: NapsuMQ usage"
+   ]
   },
   {
    "cell_type": "code",
@@ -322,9 +322,9 @@
     "inference_rng, sampling_rng = d3p.random.split(rng)\n",
     "\n",
     "# We can define column marginal relationships that we want to preserve\n",
-    "column_feature_set = [(0, 1), (0, 5), (3, 5)]\n",
+    "required_marginals = [(0, 1), (0, 5), (3, 5)]\n",
     "\n",
-    "model = NapsuMQModel(column_feature_set=column_feature_set, use_laplace_approximation=False)\n",
+    "model = NapsuMQModel(required_marginals=required_marginals, use_laplace_approximation=False)\n",
     "result = model.fit(\n",
     "    data=orig_df,\n",
     "    rng=inference_rng,\n",
@@ -441,7 +441,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {

--- a/tests/napsu_mq/napsu_mq_test.py
+++ b/tests/napsu_mq/napsu_mq_test.py
@@ -47,14 +47,14 @@ class TestNapsuMQ(unittest.TestCase):
     # Takes about ~ 1 minute to run
     @pytest.mark.slow
     def test_NAPSUMQ_model_without_IO(self):
-        column_feature_set = [
+        required_marginals = [
             ('A', 'B'), ('B', 'C'), ('A', 'C')
         ]
 
         rng = d3p.random.PRNGKey(54363731)
         inference_rng, sampling_rng = d3p.random.split(rng)
 
-        model = NapsuMQModel(column_feature_set=column_feature_set, use_laplace_approximation=False)
+        model = NapsuMQModel(required_marginals=required_marginals, use_laplace_approximation=False)
         result = model.fit(data=self.dataframe, rng=inference_rng, epsilon=1, delta=(self.n ** (-2)))
 
         datasets = result.generate(
@@ -76,13 +76,13 @@ class TestNapsuMQ(unittest.TestCase):
     # Takes about ~ 1 minute to run
     @pytest.mark.slow
     def test_NAPSUMQ_model_with_IO(self):
-        column_feature_set = [
+        required_marginals = [
             ('A', 'B'), ('B', 'C'), ('A', 'C')
         ]
 
         rng = d3p.random.PRNGKey(69700241)
         inference_rng, sampling_rng = d3p.random.split(rng)
-        model = NapsuMQModel(column_feature_set=column_feature_set, use_laplace_approximation=False)
+        model = NapsuMQModel(required_marginals=required_marginals, use_laplace_approximation=False)
         result = model.fit(data=self.dataframe, rng=inference_rng, epsilon=1, delta=(self.n ** (-2)))
 
         napsu_result_file = NamedTemporaryFile("wb")
@@ -123,13 +123,13 @@ class TestNapsuMQ(unittest.TestCase):
     @pytest.mark.slow
     def test_NAPSUMQ_model_for_storing_defects(self):
         # Expect model to generate the same results before storing the model and after storing and loading the model
-        column_feature_set = [
+        required_marginals = [
             ('A', 'B'), ('B', 'C'), ('A', 'C')
         ]
 
         rng = d3p.random.PRNGKey(74249069)
         inference_rng, sampling_rng = d3p.random.split(rng)
-        model = NapsuMQModel(column_feature_set=column_feature_set, use_laplace_approximation=False)
+        model = NapsuMQModel(required_marginals=required_marginals, use_laplace_approximation=False)
         result = model.fit(data=self.dataframe, rng=inference_rng, epsilon=1, delta=(self.n ** (-2)))
 
         # Use the sampling rng with both generate calls to expect the same generation outcome
@@ -167,14 +167,14 @@ class TestNapsuMQ(unittest.TestCase):
     # Takes about ~ 1 minute to run
     @pytest.mark.slow
     def test_NAPSUMQ_model_with_laplace_approximation_without_IO(self):
-        column_feature_set = [
+        required_marginals = [
             ('A', 'B'), ('B', 'C'), ('A', 'C')
         ]
 
         rng = d3p.random.PRNGKey(85532350)
         inference_rng, sampling_rng = d3p.random.split(rng)
 
-        model = NapsuMQModel(column_feature_set=column_feature_set, use_laplace_approximation=True)
+        model = NapsuMQModel(required_marginals=required_marginals, use_laplace_approximation=True)
         result = model.fit(data=self.dataframe, rng=inference_rng, epsilon=1, delta=(self.n ** (-2)))
 
         datasets = result.generate(
@@ -196,14 +196,14 @@ class TestNapsuMQ(unittest.TestCase):
     # Takes about ~ 1 minute to run
     @pytest.mark.slow
     def test_NAPSUMQ_model_without_IO_single_dataset(self):
-        column_feature_set = [
+        required_marginals = [
             ('A', 'B'), ('B', 'C'), ('A', 'C')
         ]
 
         rng = d3p.random.PRNGKey(85511235)
         inference_rng, sampling_rng = d3p.random.split(rng)
 
-        model = NapsuMQModel(column_feature_set=column_feature_set, use_laplace_approximation=True)
+        model = NapsuMQModel(required_marginals=required_marginals, use_laplace_approximation=True)
         result = model.fit(data=self.dataframe, rng=inference_rng, epsilon=1, delta=(self.n ** (-2)))
 
         dataset = result.generate(

--- a/twinify/cli/napsu_loader.py
+++ b/twinify/cli/napsu_loader.py
@@ -34,9 +34,9 @@ def load_cli_napsu(
         args: argparse.Namespace, unknown_args: Iterable[str], data_description: twinify.DataDescription
     ) -> twinify.dpvi.DPVIModel:
 
-    column_feature_set = _parse_model_file(args.model_path)
+    required_marginals = _parse_model_file(args.model_path)
 
-    feature_names = reduce(set.union, column_feature_set, set())
+    feature_names = reduce(set.union, required_marginals, set())
     missing_features = feature_names.difference(data_description.columns)
     if missing_features:
         raise ParsingError(
@@ -54,6 +54,6 @@ def load_cli_napsu(
         return df
 
     return preprocessing_model.PreprocessingModel(
-        twinify.napsu_mq.NapsuMQModel(column_feature_set),
+        twinify.napsu_mq.NapsuMQModel(required_marginals),
         preprocess_drop_na_fn
     )


### PR DESCRIPTION
The previous name of the argument `column_feature_set` for `NapsuMQModel` was not very indicative of the purpose of that argument. Now renamed to `required_marginals` and a docstring added. Please check if that matches/describes the meaning well.