### PR TITLE
Fix issue #56

### DIFF
--- a/tests/dpvi/modelling/mixture_model_test.py
+++ b/tests/dpvi/modelling/mixture_model_test.py
@@ -118,6 +118,21 @@ class CombinedConstraintTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             constraint.feasible_like([1., 2., 3.])
 
+    def test_tree_flatten_unflatten(self) -> None:
+        base_constraints = [dists.constraints.positive, dists.constraints.positive_integer, dists.constraints.real_vector]
+        sizes = [1, 2, 3]
+        constraint = combined_constraint(base_constraints, sizes)
+
+        params, aux_data = constraint.tree_flatten()
+        unflattened_constraint = type(constraint).tree_unflatten(aux_data, params)
+
+        self.assertEqual(unflattened_constraint.size, constraint.size)
+        self.assertEqual(unflattened_constraint.offsets, constraint.offsets)
+
+        prototype = np.array([[1., 2., 3., 4., 5., 6.], [3., 4., 5., 10., 11., 12.]])
+        unflattened_feasible = unflattened_constraint.feasible_like(prototype)
+        feasible = constraint.feasible_like(prototype)
+        self.assertTrue(np.allclose(unflattened_feasible, feasible))
 
 class MixtureModelTest(unittest.TestCase):
 

--- a/tests/dpvi/modelling/mixture_model_test.py
+++ b/tests/dpvi/modelling/mixture_model_test.py
@@ -221,7 +221,7 @@ class MixtureModelTest(unittest.TestCase):
         mixture_model = MixtureModel(base_dists, pis)
 
         expected = combined_constraint(
-            [dists.constraints.independent(dists.constraints.real, 1), dists.constraints.positive_integer],
+            [dists.constraints.independent(dists.constraints.real, 1), dists.constraints.nonnegative_integer],
             [2, 1]
         )
 

--- a/tests/dpvi/modelling/na_model_test.py
+++ b/tests/dpvi/modelling/na_model_test.py
@@ -57,7 +57,34 @@ class NAConstraintTest(unittest.TestCase):
         base_result = base_constraint.feasible_like(prototype)
         result = constraint.feasible_like(prototype)
         self.assertTrue(np.allclose(base_result, result))
+    
+    def test_tree_flatten_unflatten(self) -> None:
+        base_constraint = dists.constraints.positive
+        constraint = na_constraint(base_constraint)
 
+        params, aux_data = constraint.tree_flatten()
+        unflattened_constraint = type(constraint).tree_unflatten(aux_data, params)
+
+        self.assertEqual(unflattened_constraint.is_discrete, constraint.is_discrete)
+
+        prototype = np.array([[1., 2., 3.], [3., 4., 5.]])
+        unflattened_feasible = unflattened_constraint.feasible_like(prototype)
+        feasible = constraint.feasible_like(prototype)
+        self.assertTrue(np.allclose(unflattened_feasible, feasible))
+
+    def test_tree_flatten_unflatten_discrete(self) -> None:
+        base_constraint = dists.constraints.positive_integer
+        constraint = na_constraint(base_constraint)
+
+        params, aux_data = constraint.tree_flatten()
+        unflattened_constraint = type(constraint).tree_unflatten(aux_data, params)
+
+        self.assertEqual(unflattened_constraint.is_discrete, constraint.is_discrete)
+
+        prototype = np.array([[1, 2, 3], [3, 4, 5]])
+        unflattened_feasible = unflattened_constraint.feasible_like(prototype)
+        feasible = constraint.feasible_like(prototype)
+        self.assertTrue(np.allclose(unflattened_feasible, feasible))
 
 class NAModelTest(unittest.TestCase):
 

--- a/twinify/dpvi/modelling/automodel.py
+++ b/twinify/dpvi/modelling/automodel.py
@@ -35,10 +35,8 @@ from .na_model import NAModel
 import numpy as np
 
 from typing import Type, Dict, Optional, Union, Tuple, List, Callable, Sequence
-from abc import ABCMeta, abstractmethod
 
 import pandas as pd
-
 
 constraint_dtype_lookup = {
     dists.constraints._Boolean: 'int',
@@ -49,6 +47,13 @@ constraint_dtype_lookup = {
     dists.constraints._IntegerInterval: 'int',
     dists.constraints._Multinomial: 'int',
 }
+
+if hasattr(dists.constraints, "_Positive"):
+    constraint_dtype_lookup[dists.constraints._Positive] = 'float'
+
+if hasattr(dists.constraints, "_IntegerNonnegative"):
+    constraint_dtype_lookup[dists.constraints._IntegerNonnegative] = 'int'
+
 
 class Distribution:
     """ Wraps a numpyro distribution and exposes relevant properties for
@@ -131,8 +136,8 @@ class Distribution:
         try:
             return canonicalize_dtype(constraint_dtype_lookup[support_constraint])
         except KeyError:
-            return ValueError("A distribution with support {} is currently \
-                not supported".format(support_constraint))
+            raise ValueError("A distribution with support {} is currently "\
+                "not supported".format(support_constraint))
 
     @property
     def support_dtype(self) -> str:

--- a/twinify/dpvi/modelling/mixture_model.py
+++ b/twinify/dpvi/modelling/mixture_model.py
@@ -111,7 +111,17 @@ class _CombinedConstraint(Constraint):
     @property
     def offsets(self) -> typing.Iterable[int]:
         return self._dim_offsets[:-1]
-
+    
+    def tree_flatten(self) -> typing.Tuple[typing.Iterable[Constraint], typing.Dict[str, typing.Any]]:
+        return self._base_constraints, {'sizes': np.diff(self._dim_offsets)}
+    
+    @classmethod
+    def tree_unflatten(cls, aux_data: typing.Dict[str, typing.Any], params: typing.Iterable[Constraint]) -> "_CombinedConstraint":
+        sizes = aux_data['sizes']
+        return _CombinedConstraint(
+            params, sizes
+        )
+    
 
 combined_constraint = _CombinedConstraint
 # TODO: need to implement a transform for this

--- a/twinify/dpvi/modelling/na_model.py
+++ b/twinify/dpvi/modelling/na_model.py
@@ -47,6 +47,13 @@ class _NAConstraint(dists.constraints.Constraint):
     @property
     def event_dim(self) -> int:
         return self.base_constraint.event_dim
+    
+    def tree_flatten(self) -> typing.Tuple[dists.constraints.Constraint, typing.Tuple]:
+        return self.base_constraint, ()
+    
+    @classmethod
+    def tree_unflatten(cls, aux_data: typing.Any, params: dists.constraints.Constraint):
+        return _NAConstraint(params)
 
 
 na_constraint = _NAConstraint


### PR DESCRIPTION
In version 0.12, numpyro introduced new API requirements for constraints. This PR adds the required methods for `_NAConstraint` and `_CombinedConstraint` as well as corresponding unit tests.

There were also previously uncaught other issues with constraints in the DPVI automodelling parts, which have been fixed as well.

Confirmed to pass all available tests for numpyro 0.12.1 and 0.10.1 .

Closes #56.