### PR TITLE
changed FullMarginalQuerySet/NapsuMQModel to raise ValueErrors if features in provided query feature sets do not match features present in data

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,6 @@
 - master:
+    - changed FullMarginalQuerySet to raise ValueErrors if features in provided query feature sets do not match features present in data
+    - changed NapsuMQModel to no longer raise an error if forced_queries_in_automatic_selection is None instead of an empty iterable
     - changed InferenceModel.fit: added show_progress and return_diagnostics arguments, removed model specific kwargs (breaking)
         NapsuMQModel.fit and DPVIModel.fit changed accordingly
     - DPVIResult no longer contains the final ELBO from model fitting (breaking)

--- a/tests/napsu_mq/mst_test.py
+++ b/tests/napsu_mq/mst_test.py
@@ -15,11 +15,12 @@
 
 import unittest
 
-
 # TODO: write tests
 
+
 class MSTTest(unittest.TestCase):
-    def setUp(self):
+
+    def setUp(self) -> None:
         pass
 
     def test_MST_selection(self):

--- a/tests/napsu_mq/napsu_mq_test.py
+++ b/tests/napsu_mq/napsu_mq_test.py
@@ -275,6 +275,36 @@ class TestNapsuMQ(unittest.TestCase):
         with self.assertRaises(ValueError):
             model.fit(data=data, rng=rng, epsilon=1, delta=(n ** (-2)))
 
+    def test_NAPSUMQ_incomplete_queries(self) -> None:
+        n = 4
+
+        data = pd.DataFrame({
+            'A': np.random.randint(500, 1000, size=n),
+            'B': np.random.randint(500, 1000, size=n),
+            'C': np.random.randint(500, 1000, size=n)
+        }, dtype='category')
+
+        rng = d3p.random.PRNGKey(42)
+
+        model = NapsuMQModel(queries=[('A', 'B'), ('A',), ('D',)])
+        with self.assertRaisesRegex(ValueError, r"not covered.*C.*"):
+            model.fit(data=data, rng=rng, epsilon=1, delta=(n ** (-2)))
+
+    def test_NAPSUMQ_nonexistent_features(self) -> None:
+        n = 4
+
+        data = pd.DataFrame({
+            'A': np.random.randint(500, 1000, size=n),
+            'B': np.random.randint(500, 1000, size=n),
+            'C': np.random.randint(500, 1000, size=n)
+        }, dtype='category')
+
+        rng = d3p.random.PRNGKey(42)
+
+        model = NapsuMQModel(queries=[('A', 'B'), ('B', 'C'), ('D',)])
+        with self.assertRaisesRegex(ValueError, r"not present.*D.*"):
+            model.fit(data=data, rng=rng, epsilon=1, delta=(n ** (-2)))
+
 
 class TestNapsuMQResult(unittest.TestCase):
 

--- a/twinify/napsu_mq/napsu_mq.py
+++ b/twinify/napsu_mq/napsu_mq.py
@@ -144,7 +144,7 @@ class NapsuMQModel(InferenceModel):
 
     def __init__(
         self, queries: Optional[Iterable[FrozenSet[str]]] = None, 
-        forced_queries_in_automatic_selection: Optional[Iterable[FrozenSet[str]]] = tuple(),
+        forced_queries_in_automatic_selection: Optional[Iterable[FrozenSet[str]]] = None,
         inference_config: NapsuMQInferenceConfig = NapsuMQInferenceConfig(),
     # required_marginals: Iterable[FrozenSet[str]] = tuple()
     ) -> None:
@@ -157,7 +157,7 @@ class NapsuMQModel(InferenceModel):
 
         super().__init__()
         if forced_queries_in_automatic_selection is None:
-            raise ValueError("forced_queries_in_automatic_selection may not be None")
+            forced_queries_in_automatic_selection = tuple()
         self._forced_queries_in_automatic_selection = forced_queries_in_automatic_selection
         self._queries = queries
         self._inference_config = inference_config


### PR DESCRIPTION
fixes #60 

(also changed NapsuMQModel to no longer raise an error if `forced_queries_in_automatic_selection` is `None` instead of an empty iterable)